### PR TITLE
Use local Electron instead global

### DIFF
--- a/AhMyth-Server/package.json
+++ b/AhMyth-Server/package.json
@@ -13,7 +13,7 @@
         "asarUnpack": "**/app/Factory/**/*"
     },
     "scripts": {
-        "start": "electron ./app",
+        "start": "npx electron ./app",
         "clean": "rm -rf ./dist",
         "pack": "npm run pack:linux32 && npm run pack:linux64  && npm run pack:win32 && npm run pack:win64",
         "pack:linux32": "electron-packager ./app $npm_package_name --out=dist/ --platform=linux --arch=ia32  --electron-version=1.6.11 --overwrite",


### PR DESCRIPTION
After run pre-builded `ahmyth` app (installed from .deb package) or `npm run start` script from sources (head of master branch) i get following error
```
(ahmyth:94694): Pango-ERROR **: 06:43:33.798: Harfbuzz version too old (1.3.1)

[1]    94694 trace trap (core dumped)  ahmyth
```
It's known issue of older versions Electron.
To fix it  -  update `electron` package dependency and rebuild app.
It's work for me
